### PR TITLE
Fix authenticated GitHub file fetches

### DIFF
--- a/bin/owners.sh
+++ b/bin/owners.sh
@@ -49,12 +49,22 @@ function get_common_prefix() {
 function fetch_owners_file() {
     local dir="$1"
     local path
+    local content
     if [[ -z "${dir}" ]]; then
         path="OWNERS"
     else
         path="${dir}/OWNERS"
     fi
-    curl -fsSL "https://github.com/${GH_REPOSITORY}/raw/${branch}/${path}" 2>/dev/null
+
+    if ! content="$(gh api \
+        --method GET \
+        -H "Accept: application/vnd.github.raw+json" \
+        "/repos/${GH_REPOSITORY}/contents/${path}" \
+        -f "ref=${branch}" 2>/dev/null)"; then
+        return 0
+    fi
+
+    printf '%s\n' "${content}"
 }
 
 # get_owners_reviewers extracts reviewers from an OWNERS file content.
@@ -109,10 +119,10 @@ ${a}"
 
 # get_pr_changed_files fetches the list of changed files for the current PR.
 function get_pr_changed_files() {
-    curl -fsSL "https://github.com/${GH_REPOSITORY}/pull/${ISSUE_NUMBER}.patch" |
-        grep '^[-+]\{3\} [ab]' |
-        sed "s#--- a/##g" |
-        sed "s#+++ b/##g" |
+    gh api \
+        --paginate \
+        "/repos/${GH_REPOSITORY}/pulls/${ISSUE_NUMBER}/files" \
+        --jq '.[].filename' |
         sort -u
 }
 

--- a/plugins/auto-cc/auto-cc.plugin.sh
+++ b/plugins/auto-cc/auto-cc.plugin.sh
@@ -9,8 +9,24 @@ branch="$(gh api /repos/${GH_REPOSITORY} | jq -r '.default_branch')"
 
 function get_reviewer_from_file() {
     local dir="${1}"
-    echo curl -fsSL "https://github.com/${GH_REPOSITORY}/raw/${branch}/${dir}/OWNERS" >&2
-    curl -fsSL "https://github.com/${GH_REPOSITORY}/raw/${branch}/${dir}/OWNERS" | yq e '.reviewers | .[]'
+    local path
+    local content
+    if [[ -z "${dir}" ]]; then
+        path="OWNERS"
+    else
+        path="${dir}/OWNERS"
+    fi
+
+    echo "Fetch ${path} from ${GH_REPOSITORY}@${branch}" >&2
+    if ! content="$(gh api \
+        --method GET \
+        -H "Accept: application/vnd.github.raw+json" \
+        "/repos/${GH_REPOSITORY}/contents/${path}" \
+        -f "ref=${branch}" 2>/dev/null)"; then
+        return 0
+    fi
+
+    printf '%s\n' "${content}" | yq e '.reviewers | .[]'
 }
 
 user_pool=()
@@ -93,7 +109,11 @@ function get_reviewers() {
     done
 }
 
-file="$(curl -fsSL "https://github.com/${GH_REPOSITORY}/pull/${ISSUE_NUMBER}.patch" | grep '^[-\+]\{3\} [ab]' | sed "s#--- a/##g" | sed "s#+++ b/##g" | sort -u)"
+file="$(gh api \
+    --paginate \
+    "/repos/${GH_REPOSITORY}/pulls/${ISSUE_NUMBER}/files" \
+    --jq '.[].filename' |
+    sort -u)"
 
 echo "Modify files:" >&2
 for f in ${file}; do


### PR DESCRIPTION
## Summary

- fetch `OWNERS` files through the authenticated GitHub Contents API
- retrieve changed file names through the paginated pull request Files API
- treat missing `OWNERS` files as empty instead of parsing an API error response

## Root cause

The bot downloaded raw repository files and pull request patches with unauthenticated `curl` requests. Those requests could hit GitHub's anonymous rate limit and fail with HTTP 429.

## Impact

Repository content and pull request metadata now use the token already provided to `gh`, including for private repositories, and avoid the anonymous request limit.

## Validation

- `git diff --check`
- `bash -n bin/*.sh plugins/*/*.sh entrypoint.sh`
- verified authenticated Contents API success and 404 handling
- verified paginated pull request file retrieval against PR #57

Closes #61
