### PR TITLE
add execution details link to bot replies

### DIFF
--- a/bin/comment.sh
+++ b/bin/comment.sh
@@ -1,3 +1,19 @@
 #!/usr/bin/env bash
 
-gh "${ISSUE_KIND}" -R "${GH_REPOSITORY}" comment "${ISSUE_NUMBER}" --body "${1}"
+body="${1}"
+
+if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    server_url="${GITHUB_SERVER_URL:-https://github.com}"
+    repository="${GITHUB_REPOSITORY:-${GH_REPOSITORY}}"
+    run_url="${server_url%/}/${repository}/actions/runs/${GITHUB_RUN_ID}"
+    body="${body}
+
+<details>
+<summary>Execution details</summary>
+
+[Open the execution log](${run_url})
+
+</details>"
+fi
+
+gh "${ISSUE_KIND}" -R "${GH_REPOSITORY}" comment "${ISSUE_NUMBER}" --body "${body}"


### PR DESCRIPTION
## Summary

- append a link to the current workflow execution to bot comments
- keep the execution link inside a collapsed `Execution details` section
- preserve the original comment body and local behavior when no workflow run is present
- build the URL from GitHub-provided server, repository, and run variables for GitHub Enterprise compatibility

## Why

Bot replies did not provide a direct path to the workflow execution that handled the command, making failures slower to investigate. The collapsed section makes the execution log easy to reach without adding visual noise to every reply.

## Validation

- ran `bash -n` against all shell scripts
- verified the generated comment body and workflow URL with a mocked `gh` command
- ran `git diff --check`
