### PR TITLE
Trigger auto-merge check when WIP label is removed

### DIFF
--- a/bin/check-wip.sh
+++ b/bin/check-wip.sh
@@ -27,4 +27,5 @@ if [[ "${wip}" == "true" && "${has_label}" != "true" ]]; then
     add-labels.sh "${WIP_LABEL}"
 elif [[ "${wip}" != "true" && "${has_label}" == "true" ]]; then
     remove-labels.sh "${WIP_LABEL}"
+    check-auto-merge.sh
 fi


### PR DESCRIPTION
When the WIP label is removed, call `check-auto-merge.sh` to trigger the auto-merge check.