### PR TITLE
pr-merge: merge directly first and surface the real error

### DIFF
--- a/bin/pr-merge.sh
+++ b/bin/pr-merge.sh
@@ -27,5 +27,25 @@ if [[ -n "${blocking_labels}" ]]; then
 fi
 
 echo "PR ${GH_REPOSITORY}#${ISSUE_NUMBER} merge by ${LOGIN}"
-gh "${ISSUE_KIND}" -R "${GH_REPOSITORY}" merge "${ISSUE_NUMBER}" --auto "${args}" ||
-  echo "[FAIL] Failed to merge the PR. Please ensure all required checks have passed and there are no conflicts."
+
+# try_merge runs gh merge, printing its output and keeping the error of the
+# last failed attempt for the [FAIL] reply.
+merge_error=""
+function try_merge() {
+  local out
+  if out="$(gh "${ISSUE_KIND}" -R "${GH_REPOSITORY}" merge "${ISSUE_NUMBER}" "$@" 2>&1)"; then
+    [[ -n "${out}" ]] && echo "${out}"
+    return 0
+  fi
+  [[ -n "${out}" ]] && echo "${out}"
+  merge_error="$(echo "${out}" | tr '\n' ' ' | sed 's/  */ /g')"
+  return 1
+}
+
+if ! try_merge "${args}"; then
+  # A direct merge fails when required checks are still pending; fall back
+  # to enabling auto-merge so GitHub merges once they pass.
+  if ! try_merge --auto "${args}"; then
+    echo "[FAIL] Failed to merge the PR: ${merge_error:-unknown error}"
+  fi
+fi


### PR DESCRIPTION
Hit this on DaoCloud/public-image-mirror#45947: a `/approve` + `/lgtm` comment triggered the merge, the bot replied "Failed to merge the PR. Please ensure all required checks have passed and there are no conflicts", but the actual error in the Actions log was:

```
GraphQL: Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
```

Two problems in `bin/pr-merge.sh`:

- gh's stderr was swallowed, so the `[FAIL]` reply always showed the generic hint above, which misled the diagnosis (the real cause there was branch protection push restrictions, not checks or conflicts).
- It only ever ran `gh pr merge --auto`. Enabling auto-merge fails with "Pull request is in clean status" when the PR is already mergeable — the common case on repos without required status checks — so the bot could never merge such PRs even with the right permissions.

Now it tries a direct merge first, falls back to `--auto` when that fails (e.g. required checks still pending), and includes gh's actual error in the `[FAIL]` reply.

Verified the three paths (direct ok / direct fails then auto ok / both fail) with a mocked `gh`.
